### PR TITLE
Change idref local to idref bean

### DIFF
--- a/benchmark/Model/mainBenchmark_full.xml
+++ b/benchmark/Model/mainBenchmark_full.xml
@@ -16,7 +16,7 @@ Caiani, A., Godin, A., Caverzasi, E., Ricetti, L., Russo, A., Gallegati, M., Kin
 			scope="singleton">
 			
 		<property name="simulationBeanName">
-		   <idref local="macroSimulation"/>
+		   <idref bean="macroSimulation"/>
 		</property>
 	
 		<property name="numSimulations" value="1"/>	

--- a/benchmark/Model/mainBenchmark_light.xml
+++ b/benchmark/Model/mainBenchmark_light.xml
@@ -16,7 +16,7 @@ Caiani, A., Godin, A., Caverzasi, E., Ricetti, L., Russo, A., Gallegati, M., Kin
 			scope="singleton">
 			
 		<property name="simulationBeanName">
-		   <idref local="macroSimulation"/>
+		   <idref bean="macroSimulation"/>
 		</property>
 	
 		<property name="numSimulations" value="1"/>	

--- a/benchmark/Model/mainSerialization.xml
+++ b/benchmark/Model/mainSerialization.xml
@@ -16,7 +16,7 @@ Caiani, A., Godin, A., Caverzasi, E., Ricetti, L., Russo, A., Gallegati, M., Kin
 			scope="singleton">
 			
 		<property name="simulationBeanName">
-		   <idref local="macroSimulation"/>
+		   <idref bean="macroSimulation"/>
 		</property>
 	
 		<property name="numSimulations" value="1"/>	

--- a/benchmark/Model/modelBenchmark_full.xml
+++ b/benchmark/Model/modelBenchmark_full.xml
@@ -1437,7 +1437,7 @@ Caiani, A., Godin, A., Caverzasi, E., Ricetti, L., Russo, A., Gallegati, M., Kin
 	<bean id="capitalFirmsFactory" scope="simulation"
 		class="org.springframework.beans.factory.config.ObjectFactoryCreatingFactoryBean">
 		<property name="targetBeanName">
-			<idref local="capitalFirmPrototype" />
+			<idref bean="capitalFirmPrototype" />
 		</property>
 	</bean>
 	
@@ -1892,7 +1892,7 @@ Caiani, A., Godin, A., Caverzasi, E., Ricetti, L., Russo, A., Gallegati, M., Kin
 	<bean id="consumptionFirmsFactory" scope="simulation"
 		class="org.springframework.beans.factory.config.ObjectFactoryCreatingFactoryBean">
 		<property name="targetBeanName">
-			<idref local="consumptionFirmPrototype" />
+			<idref bean="consumptionFirmPrototype" />
 		</property>
 	</bean>
 	
@@ -2179,7 +2179,7 @@ Caiani, A., Godin, A., Caverzasi, E., Ricetti, L., Russo, A., Gallegati, M., Kin
 	<bean id="banksFactory" scope="simulation"
 		class="org.springframework.beans.factory.config.ObjectFactoryCreatingFactoryBean">
 		<property name="targetBeanName">
-			<idref local="bankPrototype" />
+			<idref bean="bankPrototype" />
 		</property>
 	</bean>
 	
@@ -2610,7 +2610,7 @@ Caiani, A., Godin, A., Caverzasi, E., Ricetti, L., Russo, A., Gallegati, M., Kin
 	<bean id="householdsFactory" scope="simulation"
 		class="org.springframework.beans.factory.config.ObjectFactoryCreatingFactoryBean">
 		<property name="targetBeanName">
-			<idref local="householdPrototype" />
+			<idref bean="householdPrototype" />
 		</property>
 	</bean>
 	
@@ -2802,7 +2802,7 @@ Caiani, A., Godin, A., Caverzasi, E., Ricetti, L., Russo, A., Gallegati, M., Kin
 	<bean id="governmentsFactory" scope="simulation"
 		class="org.springframework.beans.factory.config.ObjectFactoryCreatingFactoryBean">
 		<property name="targetBeanName">
-			<idref local="governmentPrototype" />
+			<idref bean="governmentPrototype" />
 		</property>
 	</bean>
 	
@@ -2902,7 +2902,7 @@ Caiani, A., Godin, A., Caverzasi, E., Ricetti, L., Russo, A., Gallegati, M., Kin
 	<bean id="centralBanksFactory" scope="simulation"
 		class="org.springframework.beans.factory.config.ObjectFactoryCreatingFactoryBean">
 		<property name="targetBeanName">
-			<idref local="centralBankPrototype" />
+			<idref bean="centralBankPrototype" />
 		</property>
 	</bean>
 	

--- a/benchmark/Model/modelBenchmark_light.xml
+++ b/benchmark/Model/modelBenchmark_light.xml
@@ -1451,7 +1451,7 @@ Caiani, A., Godin, A., Caverzasi, E., Ricetti, L., Russo, A., Gallegati, M., Kin
 	<bean id="capitalFirmsFactory" scope="simulation"
 		class="org.springframework.beans.factory.config.ObjectFactoryCreatingFactoryBean">
 		<property name="targetBeanName">
-			<idref local="capitalFirmPrototype" />
+			<idref bean="capitalFirmPrototype" />
 		</property>
 	</bean>
 	
@@ -1913,7 +1913,7 @@ Caiani, A., Godin, A., Caverzasi, E., Ricetti, L., Russo, A., Gallegati, M., Kin
 	<bean id="consumptionFirmsFactory" scope="simulation"
 		class="org.springframework.beans.factory.config.ObjectFactoryCreatingFactoryBean">
 		<property name="targetBeanName">
-			<idref local="consumptionFirmPrototype" />
+			<idref bean="consumptionFirmPrototype" />
 		</property>
 	</bean>
 	
@@ -2206,7 +2206,7 @@ Caiani, A., Godin, A., Caverzasi, E., Ricetti, L., Russo, A., Gallegati, M., Kin
 	<bean id="banksFactory" scope="simulation"
 		class="org.springframework.beans.factory.config.ObjectFactoryCreatingFactoryBean">
 		<property name="targetBeanName">
-			<idref local="bankPrototype" />
+			<idref bean="bankPrototype" />
 		</property>
 	</bean>
 	
@@ -2607,7 +2607,7 @@ Caiani, A., Godin, A., Caverzasi, E., Ricetti, L., Russo, A., Gallegati, M., Kin
 	<bean id="householdsFactory" scope="simulation"
 		class="org.springframework.beans.factory.config.ObjectFactoryCreatingFactoryBean">
 		<property name="targetBeanName">
-			<idref local="householdPrototype" />
+			<idref bean="householdPrototype" />
 		</property>
 	</bean>
 	
@@ -2799,7 +2799,7 @@ Caiani, A., Godin, A., Caverzasi, E., Ricetti, L., Russo, A., Gallegati, M., Kin
 	<bean id="governmentsFactory" scope="simulation"
 		class="org.springframework.beans.factory.config.ObjectFactoryCreatingFactoryBean">
 		<property name="targetBeanName">
-			<idref local="governmentPrototype" />
+			<idref bean="governmentPrototype" />
 		</property>
 	</bean>
 	
@@ -2900,7 +2900,7 @@ Caiani, A., Godin, A., Caverzasi, E., Ricetti, L., Russo, A., Gallegati, M., Kin
 	<bean id="centralBanksFactory" scope="simulation"
 		class="org.springframework.beans.factory.config.ObjectFactoryCreatingFactoryBean">
 		<property name="targetBeanName">
-			<idref local="centralBankPrototype" />
+			<idref bean="centralBankPrototype" />
 		</property>
 	</bean>
 	

--- a/benchmark/Model/modelSerialization.xml
+++ b/benchmark/Model/modelSerialization.xml
@@ -1343,7 +1343,7 @@ Caiani, A., Godin, A., Caverzasi, E., Ricetti, L., Russo, A., Gallegati, M., Kin
 	<bean id="capitalFirmsFactory" scope="simulation"
 		class="org.springframework.beans.factory.config.ObjectFactoryCreatingFactoryBean">
 		<property name="targetBeanName">
-			<idref local="capitalFirmPrototype" />
+			<idref bean="capitalFirmPrototype" />
 		</property>
 	</bean>
 	
@@ -1798,7 +1798,7 @@ Caiani, A., Godin, A., Caverzasi, E., Ricetti, L., Russo, A., Gallegati, M., Kin
 	<bean id="consumptionFirmsFactory" scope="simulation"
 		class="org.springframework.beans.factory.config.ObjectFactoryCreatingFactoryBean">
 		<property name="targetBeanName">
-			<idref local="consumptionFirmPrototype" />
+			<idref bean="consumptionFirmPrototype" />
 		</property>
 	</bean>
 	
@@ -2085,7 +2085,7 @@ Caiani, A., Godin, A., Caverzasi, E., Ricetti, L., Russo, A., Gallegati, M., Kin
 	<bean id="banksFactory" scope="simulation"
 		class="org.springframework.beans.factory.config.ObjectFactoryCreatingFactoryBean">
 		<property name="targetBeanName">
-			<idref local="bankPrototype" />
+			<idref bean="bankPrototype" />
 		</property>
 	</bean>
 	
@@ -2517,7 +2517,7 @@ Caiani, A., Godin, A., Caverzasi, E., Ricetti, L., Russo, A., Gallegati, M., Kin
 	<bean id="householdsFactory" scope="simulation"
 		class="org.springframework.beans.factory.config.ObjectFactoryCreatingFactoryBean">
 		<property name="targetBeanName">
-			<idref local="householdPrototype" />
+			<idref bean="householdPrototype" />
 		</property>
 	</bean>
 	
@@ -2709,7 +2709,7 @@ Caiani, A., Godin, A., Caverzasi, E., Ricetti, L., Russo, A., Gallegati, M., Kin
 	<bean id="governmentsFactory" scope="simulation"
 		class="org.springframework.beans.factory.config.ObjectFactoryCreatingFactoryBean">
 		<property name="targetBeanName">
-			<idref local="governmentPrototype" />
+			<idref bean="governmentPrototype" />
 		</property>
 	</bean>
 	
@@ -2809,7 +2809,7 @@ Caiani, A., Godin, A., Caverzasi, E., Ricetti, L., Russo, A., Gallegati, M., Kin
 	<bean id="centralBanksFactory" scope="simulation"
 		class="org.springframework.beans.factory.config.ObjectFactoryCreatingFactoryBean">
 		<property name="targetBeanName">
-			<idref local="centralBankPrototype" />
+			<idref bean="centralBankPrototype" />
 		</property>
 	</bean>
 	


### PR DESCRIPTION
Since Spring 4.0, the attribute `local` is obsolete and should be replaced by the attribute `bean`. See https://docs.spring.io/spring/docs/5.1.0.RELEASE/spring-framework-reference/core.html#beans-idref-element